### PR TITLE
CI: Docker image build and push to our private ACR

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,11 +1,14 @@
-on: [push]
+on:
+  push:
+    branches:
+      - main
+
 name: Build and Push Docker Image
 
 jobs:
     build-and-push:
         runs-on: ubuntu-latest
         steps:
-        # checkout the repo
         - name: 'Checkout GitHub Action'
           uses: actions/checkout@main
           

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - ci
 
 name: Build and Push Docker Image
 
@@ -24,5 +25,5 @@ jobs:
             username: ${{ secrets.REGISTRY_USERNAME }}
             password: ${{ secrets.REGISTRY_PASSWORD }}
         - run: |
-            docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} .
-            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }}
+            docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:latest .
+            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} --all-tags

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,4 +26,4 @@ jobs:
             password: ${{ secrets.REGISTRY_PASSWORD }}
         - run: |
             docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:latest .
-            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} --all-tags
+            docker push --all-tags ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,8 @@
 on: [push]
-name: Linux_Container_Workflow
+name: Build and Push Docker Image
 
 jobs:
-    build-and-deploy:
+    build-and-push:
         runs-on: ubuntu-latest
         steps:
         # checkout the repo
@@ -23,15 +23,3 @@ jobs:
         - run: |
             docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }} .
             docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }}
-
-        - name: 'Deploy to Azure Container Instances'
-          uses: 'azure/aci-deploy@v1'
-          with:
-            resource-group: ${{ secrets.RESOURCE_GROUP }}
-            dns-name-label: ${{ secrets.RESOURCE_GROUP }}${{ github.run_number }}
-            image: ${{ secrets.REGISTRY_LOGIN_SERVER }}/pulumi-go:${{ github.sha }}
-            registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            registry-username: ${{ secrets.REGISTRY_USERNAME }}
-            registry-password: ${{ secrets.REGISTRY_PASSWORD }}
-            name: whereismytransport
-            location: 'north europe'


### PR DESCRIPTION
Implemented a basic CI action which:
 - is triggered when pushing code to `main`,
 - logs into our ACR using an AD service principal,
 - builds the `pulumi-go` docker image tagged with the commit SHA and latest, 
 - pushes the docker image to our private Azure Container Registry.