### PR TITLE
Using stderr

### DIFF
--- a/src/pulumi-go.sh
+++ b/src/pulumi-go.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-#set -e
-
 # Go to Pulumi project directory (mounted at runtime).
 cd project
 
@@ -21,3 +19,5 @@ pulumi login $PULUMI_BACKEND --non-interactive --color never --logtostderr
 # Requires ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID, ARM_SUBSCRIPTION_ID environment variables.
 # These provide Azure privileges by service principal - https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/#service-principal-authentication
 pulumi $@ --non-interactive --color never --logtostderr
+
+# Note: pulumi does not use standard exit codes so using stderr is necessary

--- a/src/pulumi-go.sh
+++ b/src/pulumi-go.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#set -e
+
 # Go to Pulumi project directory (mounted at runtime).
 cd project
 
@@ -18,6 +20,4 @@ pulumi login $PULUMI_BACKEND --non-interactive --color never --logtostderr
 # Run Pulumi with the provided command (and arguments) provided at docker run.
 # Requires ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID, ARM_SUBSCRIPTION_ID environment variables.
 # These provide Azure privileges by service principal - https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/#service-principal-authentication
-pulumi $@ --non-interactive --color never
-
-exit 0
+pulumi $@ --non-interactive --color never --logtostderr


### PR DESCRIPTION
Pulumi does not use standard exit codes so using stderr is necessary